### PR TITLE
security: bump log4net to 2.0.10

### DIFF
--- a/DownloadManager.Library/DownloadManager.Library.csproj
+++ b/DownloadManager.Library/DownloadManager.Library.csproj
@@ -44,7 +44,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
+      <HintPath>..\packages\log4net.2.0.10\lib\net45-full\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/DownloadManager.Library/packages.config
+++ b/DownloadManager.Library/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Common.Logging" version="3.0.0" targetFramework="net452" />
   <package id="Common.Logging.Core" version="3.0.0" targetFramework="net452" />
-  <package id="log4net" version="2.0.5" targetFramework="net452" />
+  <package id="log4net" version="2.0.10" targetFramework="net452" />
   <package id="MySql.Data" version="6.9.8" targetFramework="net452" />
   <package id="Quartz" version="2.3.3" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
## Summary
- bump log4net from 2.0.5 to 2.0.10
- updates old-style packages.config + csproj hint path

## Security
- addresses CVE-2018-1285 reported by Dependabot

Closes #5
